### PR TITLE
Adds in a nukie only .357

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -366,6 +366,16 @@ var/list/uplink_items = list()
 	item = /obj/item/weapon/gun/projectile/revolver
 	cost = 13
 	surplus = 50
+	excludefrom = list(/datum/game_mode/nuclear)
+
+/datum/uplink_item/dangerous/revolvernukie
+	name = "Syndicate .357 Revolver"
+	reference = "SRN"
+	desc = "A brutally simple syndicate revolver that fires .357 Magnum cartridges and has 7 chambers."
+	item = /obj/item/weapon/gun/projectile/revolver
+	cost = 7
+	surplus = 0
+	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/dangerous/smg
 	name = "C-20r Submachine Gun"


### PR DESCRIPTION
This PR adds in a new entry for the .357 for nukies only. I made this PR because it was mentioned that the .357 costs 13 points for nukies, where other, much more powerful weapons, like the 50 caliber sniper rifle only costs 16, only 3 points more. Not to mention no nukie I have ever seen or heard has ever used a .357. So this PR lowers the cost for the .357 to 6 points for nukies. I want to emphasis that this in no way affects the traitor .357 cost, nor the surplus chance for .357s, it only makes the nukie .357 cheaper to make it more competitive with other weapons in price. Now, if 6 is too low, I would be more then happy to raise it.